### PR TITLE
🚸 Disable roll button

### DIFF
--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -118,6 +118,7 @@
                         {{ $t('open.referee.createLobby') }}
                     </ContentButton>
                     <ContentButton
+                        v-if="false"
                         class="referee__matchup__header__create_lobby__button content_button--red content_button--red_sm"
                         :class="{
                             'content_button--disabled': !matchup.mp || matchup.stage?.stageType === 0 || !runningLobby,


### PR DESCRIPTION
rescup's ruleset is not compatible with automated rolling (different team 1 for bans and picks)